### PR TITLE
fix dead players acid remaining

### DIFF
--- a/src/main/java/com/snake/SnakeController.java
+++ b/src/main/java/com/snake/SnakeController.java
@@ -246,6 +246,7 @@ public class SnakeController
 				int randomIndex = generator.nextInt(onFoodPlayers.size());
 				SnakePlayer snakePlayerGrow = onFoodPlayers.get(randomIndex);
 				snakePlayerGrow.setShouldGrow(true);
+				snakePlayerGrow.increaseScore();
 				snakePlayerGrow.setOverHeadText("+1");
 				respawnAllFood();
 			}
@@ -255,6 +256,7 @@ public class SnakeController
 				{
 					snakePlayerGrow.setShouldGrow(true);
 					snakePlayerGrow.setOverHeadText("+1");
+					snakePlayerGrow.increaseScore();
 					snakePlayerGrow.setFoodLocation(getRandomPointInGrid());
 				}
 			}

--- a/src/main/java/com/snake/SnakePlayer.java
+++ b/src/main/java/com/snake/SnakePlayer.java
@@ -110,6 +110,7 @@ public class SnakePlayer
 			setOverHeadText("Game Over!");
 			player.setAnimation(2925);
 			player.setAnimationFrame(0);
+			snakeTrail.clear();
 		}
 	}
 

--- a/src/main/java/com/snake/SnakePlayer.java
+++ b/src/main/java/com/snake/SnakePlayer.java
@@ -99,7 +99,6 @@ public class SnakePlayer
 		{
 			snakeTrail.add(currentLocation);
 			shouldGrow = false;
-			increaseScore();
 		}
 		else
 		{

--- a/src/main/java/com/snake/SnakePlayer.java
+++ b/src/main/java/com/snake/SnakePlayer.java
@@ -40,11 +40,16 @@ public class SnakePlayer
 	@Setter
 	private WorldPoint foodLocation;
 
+	@Getter
+	@Setter
+	private int score;
+
 	public SnakePlayer(Player player, Color color, boolean isActivePlayer)
 	{
 		this.player = player;
 		this.color = color;
 		this.isActivePlayer = isActivePlayer;
+		this.score = INITIAL_TRAIL_SIZE;
 
 		currentLocation = player.getWorldLocation();
 		previousLocation = currentLocation;
@@ -58,12 +63,7 @@ public class SnakePlayer
 		foodLocation = null;
 	}
 
-	public int getScore()
-	{
-		return Math.max(0, snakeTrail.size() - INITIAL_TRAIL_SIZE);
-	}
-
-	public void setOverHeadText(String text)
+    public void setOverHeadText(String text)
 	{
 		setOverHeadText(text, 50);
 	}
@@ -82,6 +82,11 @@ public class SnakePlayer
 		}
 	}
 
+	public void increaseScore()
+	{
+		score++;
+	}
+
 	public void updateLocation()
 	{
 		previousLocation = currentLocation;
@@ -94,6 +99,7 @@ public class SnakePlayer
 		{
 			snakeTrail.add(currentLocation);
 			shouldGrow = false;
+			increaseScore();
 		}
 		else
 		{


### PR DESCRIPTION
I noticed in multiplayer with 3+ players, when a player dies the tiles their trail was on remain dangerous. I believe clearing the snakeTrail when the player dies fixes this. Did a bit of testing with some friends and wasn't able to replicate the bug on this version.